### PR TITLE
Add Bankless Media Partnership proposal

### DIFF
--- a/proposals/13-bankless-media-partnership.md
+++ b/proposals/13-bankless-media-partnership.md
@@ -1,0 +1,32 @@
+# Proposal 13 - Bankless Media Partnership
+Implementation for Proposal 13, transferring 30,000 USDC to `bankless.eth` (`0x844e211e291077B11221c0F18615a64F2Ff19c26`)
+
+## Implementation
+| field | value |
+| :------------- | :-------------: |
+| targets | [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48]
+| proposalData | [0xa9059cbb000000000000000000000000844e211e291077b11221c0f18615a64f2ff19c2600000000000000000000000000000000000000000000000000000006fc23ac00]
+
+## Generation
+Generated using the following function call(s) and the DAOCheck tool
+```json
+"calls": [
+        {
+            "target": "USDC",
+            "name": "transfer",
+            "parameters": [
+                {
+                    "name": "recipient",
+                    "type": "address",
+                    "value": "0x844e211e291077B11221c0F18615a64F2Ff19c26"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256",
+                    "value": "30000000000"
+                }
+            ]
+        }
+    ]
+```
+Note that USDC uses 6 decimals and hence `amount = 30,000 * 10^6`. The USDC address being used is `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`.


### PR DESCRIPTION
# Motivation
Implementation for #5 

# Code used to implement
Firstly, I used `daocheck`. Then, to verify this was correct, I wrote my own script with the following code to generate the data.

```javascript
const bankless = "0x844e211e291077B11221c0F18615a64F2Ff19c26"
// 30,000 * 10^6 (6, because `USDC::decimals()` == 6)
const totalTransferAmount = "30000000000"
const usdcAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"

const sendToBankless = web3.eth.abi.encodeFunctionCall(
{
    name: 'transfer',
    type: 'function',
    inputs: [
        {
            type: 'address',
            name: 'recipient',
        },
        {
            type: 'uint256',
            name: 'amount',
        },
    ],
},
[bankless, totalTransferAmount]
)

console.log("===== Send USDC to bankless.eth =====")
console.log(sendToBankless)
console.log("===== USDC Address =====")
console.log(usdcAddress)
```
Both outputs matched, and are included in the PR.